### PR TITLE
fix: add missing null checks for user.id in notification screen and p…

### DIFF
--- a/app/(tabs)/notification.tsx
+++ b/app/(tabs)/notification.tsx
@@ -74,7 +74,8 @@ const getNotificationTypeFromContent = (content: string): string => {
 
 export default function NotificationScreen() {
   const [notifications, setNotifications] = useState<NotificationResponse[]>([]);
-  const userId = useSelector((state: RootState) => state.auth.user.id);
+  const user = useSelector((state: RootState) => state.auth.user);
+  const userId = user?.id;
   const { getAllNotifications, clickNotification, viewAllNotifications, loading: isLoading } = useNotificationService();
   const { latestNotification } = useContext(PusherContext);
 

--- a/contexts/pusher/PusherProvider.tsx
+++ b/contexts/pusher/PusherProvider.tsx
@@ -64,6 +64,11 @@ export const PusherProvider = ({ children }: { children: ReactNode }) => {
     }
 
     // Determine Pusher channel for this role
+    if (!user.id || !user.role) {
+      setConnectionError('User ID or role is missing');
+      return undefined;
+    }
+
     const channelName = getChannelForRole(user.role as AccountRole, Number(user.id));
     if (!channelName) {
       setConnectionError(`No channel defined for role: ${user.role}`);


### PR DESCRIPTION
…usher provider

- Fix direct access to state.auth.user.id in notification screen
- Add null checks for user.id and user.role in PusherProvider
- These were the remaining sources of 'Cannot read property id of null' errors