### PR TITLE
fix: prevent user.id access during logout transitions and navigation

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -57,12 +57,12 @@ function AuthHandler() {
         console.log("🔄 Not logged in, redirecting to login");
         router.replace("/login");
       } else {
-        // Only navigate to tabs if user is properly loaded
-        if (user.id && user.email && user.role) {
+        // Only navigate to tabs if user is properly loaded and has all required properties
+        if (user && typeof user === 'object' && user.id && user.email && user.role) {
           console.log("✅ User authenticated, navigating to tabs");
           router.replace("/(tabs)/import");
         } else {
-          console.warn("⚠️ User object incomplete, redirecting to login");
+          console.warn("⚠️ User object incomplete, redirecting to login", { user });
           router.replace("/login");
         }
       }

--- a/contexts/pusher/PusherProvider.tsx
+++ b/contexts/pusher/PusherProvider.tsx
@@ -29,7 +29,7 @@ export const PusherProvider = ({ children }: { children: ReactNode }) => {
   const [isConnected, setIsConnected] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
-  const { user, isLoggedIn } = useSelector((state: RootState) => state.auth);
+  const { user, isLoggedIn, isLoggingOut } = useSelector((state: RootState) => state.auth);
 
   // Create Pusher instance only once
   const pusherRef = useRef<any>(null);
@@ -47,6 +47,12 @@ export const PusherProvider = ({ children }: { children: ReactNode }) => {
   };
 
   useEffect(() => {
+    // Don't set up Pusher if logging out
+    if (isLoggingOut) {
+      console.log('⏸️ Skipping Pusher setup - logout in progress');
+      return undefined;
+    }
+
     // Only set up Pusher if user is authenticated and has a role
     if (!isLoggedIn || !user) {
       // Clean up existing connection if user is not authenticated
@@ -137,7 +143,7 @@ export const PusherProvider = ({ children }: { children: ReactNode }) => {
         channelRef.current = null;
       }
     };
-  }, [user, isLoggedIn]);
+  }, [user, isLoggedIn, isLoggingOut]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/hooks/useAppStateRestore.ts
+++ b/hooks/useAppStateRestore.ts
@@ -7,36 +7,50 @@ import { RootState } from '@/redux/store';
 
 export const useAppStateRestore = () => {
   const dispatch = useDispatch();
-  const { isLoggedIn, user } = useSelector((state: RootState) => state.auth);
+  const authState = useSelector((state: RootState) => state.auth);
   const appState = useRef(AppState.currentState);
 
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
       console.log(`🔄 App state changed from ${appState.current} to ${nextAppState}`);
-      
+
       // When app comes back to foreground from background
       if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
         console.log('📱 App came to foreground, checking auth state...');
-        
-        // Check if Redux state is inconsistent with AsyncStorage
-        const [accessToken, refreshToken] = await Promise.all([
-          AsyncStorage.getItem("access_token"),
-          AsyncStorage.getItem("refresh_token")
-        ]);
 
-        // If we have tokens in storage but no user in Redux, restore the state
-        if (accessToken && refreshToken && (!isLoggedIn || !user)) {
-          console.log('🔄 Restoring auth state after app resume...');
-          dispatch(restoreAuthState({ 
-            access_token: accessToken, 
-            refresh_token: refreshToken 
-          }));
+        // Get current auth state safely
+        const { isLoggedIn, user, isLoggingOut } = authState;
+
+        // Don't restore state if we're in the middle of logging out
+        if (isLoggingOut) {
+          console.log('⏸️ Skipping auth state check - logout in progress');
+          appState.current = nextAppState;
+          return;
         }
-        
-        // If we have user in Redux but no tokens in storage, clear Redux state
-        else if ((isLoggedIn || user) && (!accessToken || !refreshToken)) {
-          console.log('🧹 Clearing inconsistent auth state...');
-          // This would require a clearAuthState action, but for now we'll let the normal flow handle it
+
+        try {
+          // Check if Redux state is inconsistent with AsyncStorage
+          const [accessToken, refreshToken] = await Promise.all([
+            AsyncStorage.getItem("access_token"),
+            AsyncStorage.getItem("refresh_token")
+          ]);
+
+          // If we have tokens in storage but no user in Redux, restore the state
+          if (accessToken && refreshToken && (!isLoggedIn || !user)) {
+            console.log('🔄 Restoring auth state after app resume...');
+            dispatch(restoreAuthState({
+              access_token: accessToken,
+              refresh_token: refreshToken
+            }));
+          }
+
+          // If we have user in Redux but no tokens in storage, clear Redux state
+          else if ((isLoggedIn || user) && (!accessToken || !refreshToken)) {
+            console.log('🧹 Clearing inconsistent auth state...');
+            // This would require a clearAuthState action, but for now we'll let the normal flow handle it
+          }
+        } catch (error) {
+          console.error('❌ Error in app state restoration:', error);
         }
       }
 
@@ -48,5 +62,5 @@ export const useAppStateRestore = () => {
     return () => {
       subscription?.remove();
     };
-  }, [dispatch, isLoggedIn, user]);
+  }, [dispatch]); // Remove user and isLoggedIn from dependencies to prevent re-running during logout
 };


### PR DESCRIPTION
- Fix useAppStateRestore hook dependencies to prevent re-running during logout
- Add isLoggingOut check to prevent state restoration during logout process
- Enhance user object validation in AuthHandler navigation logic
- Add logout state guard to PusherProvider to prevent setup during logout
- Remove problematic dependencies that cause hooks to re-run during state transitions

This should resolve the remaining 'Cannot read property id of null' error that occurs during the navigation transition after logout completion.